### PR TITLE
Fix python_version format

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format

--- a/salesforce.json
+++ b/salesforce.json
@@ -15,10 +15,7 @@
     "package_name": "phantom_salesforce",
     "main_module": "salesforce_connector.py",
     "min_phantom_version": "5.5.0",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "app_wizard_version": "1.0.0",
     "rest_handler": "salesforce_connector.handle_request",


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)