### PR TITLE
fix: remediate Salesforce July intake vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.7
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Updated development tooling.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Updated development tooling.
+* Remove Unicode format-control characters from ingested Case display fields.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
+* Make poll container identifiers unpredictable to untrusted container creators.
 * Remove Unicode format-control characters from ingested Case display fields.

--- a/salesforce_connector.py
+++ b/salesforce_connector.py
@@ -1312,10 +1312,10 @@ class SalesforceConnector(BaseConnector):
 
         try:
             artifact["source_data_identifier"] = hashlib.sha256(json.dumps(artifact)).hexdigest()
-            container["source_data_identifier"] = hashlib.sha256("{}{}".format(sobject, response["Id"])).hexdigest()
+            container["source_data_identifier"] = self._get_container_source_data_identifier(sobject, response["Id"])
         except:
             artifact["source_data_identifier"] = hashlib.sha256(json.dumps(artifact).encode()).hexdigest()
-            container["source_data_identifier"] = hashlib.sha256("{}{}".format(sobject, response["Id"]).encode()).hexdigest()
+            container["source_data_identifier"] = self._get_container_source_data_identifier(sobject, response["Id"])
 
         severity = response.get("Incident_Severity__c")
         if severity:
@@ -1326,6 +1326,13 @@ class SalesforceConnector(BaseConnector):
             container["sensitivity"] = sensitivity_mapping.get(sensitivity.lower(), "amber")
 
         return container
+
+    def _get_container_source_data_identifier(self, sobject, record_id):
+        salt = self._state.get("container_source_data_identifier_salt")
+        if not isinstance(salt, str) or not salt:
+            salt = secrets.token_urlsafe(32)
+            self._state["container_source_data_identifier_salt"] = salt
+        return hashlib.sha256(f"{salt}:{sobject}:{record_id}".encode()).hexdigest()
 
     def _batch_response_to_containers(self, response, sobject, start_index=0):
         containers = []

--- a/salesforce_connector.py
+++ b/salesforce_connector.py
@@ -25,6 +25,7 @@ import os
 import secrets
 import sys
 import time
+import unicodedata
 from urllib.parse import urlparse
 
 import encryption_helper
@@ -70,6 +71,12 @@ def _trusted_instance_origin(instance_url):
 class RetVal(tuple):
     def __new__(cls, val1, val2=None):
         return tuple.__new__(RetVal, (val1, val2))
+
+
+def _strip_format_controls(value):
+    if not isinstance(value, str):
+        return value
+    return "".join(character for character in value if unicodedata.category(character) != "Cf")
 
 
 def _delete_app_state(asset_id, app_connector=None):
@@ -1278,12 +1285,12 @@ class SalesforceConnector(BaseConnector):
             if k in skip_field_names:
                 continue
             name = self._cef_name_map.get(k, k)
-            cef[name] = v
+            cef[name] = _strip_format_controls(v)
             if k.endswith("Id") and v is not None:
                 cef_types[name] = ["salesforce object id"]
 
             if name == "Subject":
-                container_name = v
+                container_name = cef[name]
 
         if container_name is None:
             number = response.get("CaseNumber") or response.get("Id", "")


### PR DESCRIPTION
## Summary

- make scheduled-poll container identifiers unpredictable to untrusted container creators
- remove Unicode format-control characters from ingested Case display fields

## Tracking

- PAPP: [PAPP-38292](https://splunk.atlassian.net/browse/PAPP-38292)
- PSAAS: PSAAS-32761, PSAAS-33194
- Provenance: VULN-95754 / FS-4448, VULN-96765 / FS-5348

## Verification

- targeted Python 3.13 ingestion behavior check
- `python3.13 -m py_compile salesforce_connector.py`
- `ruff check salesforce_connector.py`
- `pre-commit run --all-files` (public PyPI, Python 3.13)
- `git diff --check`

Written by Codex.